### PR TITLE
TextEntity setColor() will now change the color of the Text

### DIFF
--- a/src/it/marteEngine/entity/TextEntity.java
+++ b/src/it/marteEngine/entity/TextEntity.java
@@ -23,8 +23,10 @@ public class TextEntity extends Entity {
 			this.calculateHitBox();
 		}
 		g.setFont(font);
-		if (text != null)
+		if (text != null) {
+			g.setColor(this.getColor());
 			g.drawString(text, x, y);
+		}
 	}
 
 	public Font getFont() {


### PR DESCRIPTION
I added some code to the render() method of TextEntity so that it would retrieve the color from the object and set the graphics color accordingly, thus rending the text in a color other than white, if needed.
